### PR TITLE
DS-6121 : Release opentracing_dart 0.2.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: opentracing
 description: This library is the Open Tracing API written in Dart. It is intended for use both on the server and in the browser.
-version: 0.1.2
+version: 0.2.0
 author: The OpenTracing Authors <https://groups.google.com/forum/#!forum/distributed-tracing>
 homepage: http://opentracing.io/
 

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,8 +1,8 @@
 project: dart
 language: dart
 
-# Dart 1.21.1, content_shell, lcov and sassc:
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-dart:119662
+# Dart 1.23.0, content_shell, lcov and sassc:
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:153818
 
 script:
   - pub get


### PR DESCRIPTION

Pulls Included in Release:


Requested by: @dustinlessard-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/opentracing_dart/compare/0.1.3...version-bump-opentracing_dart-0-2-0
Diff Between Last Tag and New Tag: https://github.com/Workiva/opentracing_dart/compare/0.1.3...0.2.0