### PR TITLE
wp-4680 : adjusted sdk

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: The OpenTracing Authors <https://groups.google.com/forum/#!forum/distrib
 homepage: http://opentracing.io/
 
 environment:
-  sdk: ^1.23.0
+  sdk: ">=1.23.0 <2.0.0"
 
 dev_dependencies:
   coverage: ^0.7.3


### PR DESCRIPTION
## Problem
When publishing this package, the following error was encountered:
```shell
* ^ version constraints aren't allowed for SDK constraints since older versions of pub don't support them.
  Expand it manually instead:

  environment:
    sdk: ">=1.23.0 <2.0.0
```

## Solution
Adjusted pubspect to use manual range.