### PR TITLE
export noop span

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.packages
+.pub
+pubspec.lock

--- a/lib/noop_tracer.dart
+++ b/lib/noop_tracer.dart
@@ -24,15 +24,8 @@
 /// or implied. See the License for the specific language governing permissions and limitations under
 /// the License.
 
-library opentracing_dart;
+library opentracing_noop;
 
-export 'src/abstract_span.dart';
-export 'src/abstract_tracer.dart';
-export 'src/binary_carrier.dart';
-export 'src/constants.dart';
-export 'src/errors.dart';
-export 'src/ext/tags.dart';
-export 'src/global_tracer.dart';
-export 'src/logdata.dart';
-export 'src/reference.dart';
-export 'src/span_context.dart';
+export 'src/noop_span.dart';
+export 'src/noop_span_context.dart';
+export 'src/noop_tracer.dart';

--- a/test/unit/abstract_tracer_test.dart
+++ b/test/unit/abstract_tracer_test.dart
@@ -14,7 +14,7 @@
 
 import 'package:test/test.dart';
 
-import 'package:opentracing/src/noop_tracer.dart';
+import 'package:opentracing/noop_tracer.dart';
 import 'package:opentracing/opentracing.dart';
 
 void main() {

--- a/test/unit/global_tracer_test.dart
+++ b/test/unit/global_tracer_test.dart
@@ -17,9 +17,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 
 import 'package:opentracing/opentracing.dart';
-import 'package:opentracing/src/noop_span.dart';
-import 'package:opentracing/src/noop_span_context.dart';
-import 'package:opentracing/src/noop_tracer.dart';
+import 'package:opentracing/noop_tracer.dart';
 
 void main() {
   test('Global tracer is a singleton', () {

--- a/test/unit/noop_span_test.dart
+++ b/test/unit/noop_span_test.dart
@@ -15,8 +15,7 @@
 import 'package:opentracing/src/abstract_span.dart';
 import 'package:test/test.dart';
 
-import 'package:opentracing/src/noop_span.dart';
-import 'package:opentracing/src/noop_span_context.dart';
+import 'package:opentracing/noop_tracer.dart';
 
 void main() {
   group('noopSpan: verify', () {

--- a/test/unit/noop_tracer_test.dart
+++ b/test/unit/noop_tracer_test.dart
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 import 'package:test/test.dart';
-import 'package:opentracing/src/noop_span_context.dart';
-import 'package:opentracing/src/noop_span.dart';
-import 'package:opentracing/src/noop_tracer.dart';
+import 'package:opentracing/noop_tracer.dart';
 
 void main() {
   test('Verify startSpan returns NoopSpan', () {

--- a/test/unit/span_context_test.dart
+++ b/test/unit/span_context_test.dart
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import 'package:test/test.dart';
-import 'package:opentracing/src/span_context.dart';
+import 'package:opentracing/opentracing.dart';
 
 void main() {
   group('SpanContext: verify', () {


### PR DESCRIPTION
# Description

OpenTracing specifications indicate that a Noop Tracer should be provided with Tracing implementations. We import this in some places in our code directly from `src/` and this is causing unnecessary breaking changes further down the line.

# Testing

- [ ] CI only (just exporting variables)

fyi @greglittlefield-wf @dustinlessard-wf 