### PR TITLE
Release opentracing_dart 0.2.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: opentracing
 description: This library is the Open Tracing API written in Dart. It is intended for use both on the server and in the browser.
-version: 0.2.1
+version: 0.2.2
 author: The OpenTracing Authors <https://groups.google.com/forum/#!forum/distributed-tracing>
 homepage: http://opentracing.io/
 


### PR DESCRIPTION

Pull Requests included in release:
* [Rename .analysis_options to analysis_options.yaml](https://github.com/Workiva/opentracing_dart/pull/19)
* [final-batch: Update Dockerfile to mirror smithy.yaml](https://github.com/Workiva/opentracing_dart/pull/22)
* [update build](https://github.com/Workiva/opentracing_dart/pull/23)
* [AF-2468 export noop span](https://github.com/Workiva/opentracing_dart/pull/25)


Requested by: @toddbeckman-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/opentracing_dart/compare/0.2.1...Workiva:release_0.2.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/opentracing_dart/compare/0.2.1...0.2.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4622718901682176/logs/)