### PR TITLE
Release opentracing_dart 0.2.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: opentracing
 description: This library is the Open Tracing API written in Dart. It is intended for use both on the server and in the browser.
-version: 0.2.2
+version: 0.2.3
 author: The OpenTracing Authors <https://groups.google.com/forum/#!forum/distributed-tracing>
 homepage: http://opentracing.io/
 


### PR DESCRIPTION

Pull Requests included in release:
* [fixes for dart 2](https://github.com/Workiva/opentracing_dart/pull/27)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/opentracing_dart/compare/0.2.2...Workiva:release_opentracing_dart_0.2.3
Diff Between Last Tag and New Tag: https://github.com/Workiva/opentracing_dart/compare/0.2.2...0.2.3

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4622718901682176/logs/)