### PR TITLE
AF-3505 : ActiveSpan

### DIFF
--- a/example/default/example.dart
+++ b/example/default/example.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:html';
 
 import 'package:opentracing/opentracing.dart';
@@ -38,8 +37,9 @@ void runSuccessCase() {
   }).catchError((dynamic error) {
     span.log('request_error', payload: error);
   }).whenComplete(() {
-    span.log('request_end');
-    span.finish();
+    span
+      ..log('request_end')
+      ..finish();
   });
 }
 
@@ -50,15 +50,16 @@ void runFailureCase() {
 
   HttpRequest.getString('http://httpstat.us/500').then((String result) {
     span.log('data_received', payload: result);
-  }).catchError((error) {
+  }).catchError((dynamic error) {
     span.log('request_error', payload: error);
   }).whenComplete(() {
-    span.log('request_end');
-    span.finish();
+    span
+      ..log('request_end')
+      ..finish();
   });
 }
 
-Future main() async {
+void main() {
   runSuccessCase();
   runFailureCase();
 }

--- a/example/default/example.dart
+++ b/example/default/example.dart
@@ -50,7 +50,7 @@ void runFailureCase() {
 
   HttpRequest.getString('http://httpstat.us/500').then((String result) {
     span.log('data_received', payload: result);
-  }).catchError((dynamic error) {
+  }).catchError((error) {
     span.log('request_error', payload: error);
   }).whenComplete(() {
     span

--- a/example/default/json_serializable_span.dart
+++ b/example/default/json_serializable_span.dart
@@ -11,7 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//
+// ignore_for_file: public_member_api_docs
 import 'package:opentracing/opentracing.dart';
 
 /// Abstract class that identifies other classes being serializable as json.
@@ -19,43 +20,28 @@ import 'package:opentracing/opentracing.dart';
 /// Implementing this class will enable a class to be serialized using the
 /// JSON.encode method.
 class JsonSerializableSpan {
-  // ignore: public_member_api_docs
   static const String versionField = 'version';
-  // ignore: public_member_api_docs
   static const String traceIdField = 'traceId';
-  // ignore: public_member_api_docs
   static const String spanIdField = 'spanId';
-  // ignore: public_member_api_docs
   static const String sampledField = 'sampled';
-  // ignore: public_member_api_docs
   static const String baggageField = 'baggage';
-  // ignore: public_member_api_docs
   static const String parentSpanIdField = 'parentSpanId';
-  // ignore: public_member_api_docs
   static const String operationField = 'operation';
-  // ignore: public_member_api_docs
   static const String startField = 'start';
-  // ignore: public_member_api_docs
   static const String durationField = 'duration';
-  // ignore: public_member_api_docs
   static const String tagsField = 'tags';
-  // ignore: public_member_api_docs
   static const String logsField = 'logs';
 
-  // ignore: public_member_api_docs
   Span span;
 
-  // ignore: public_member_api_docs
   JsonSerializableSpan(this.span);
 
-  // ignore: public_member_api_docs
   Map<String, dynamic> toJson() {
     return getFields();
   }
 
-  // ignore: public_member_api_docs
   Map<String, dynamic> getFields() {
-    Map<String, dynamic> fieldMap = <String, dynamic>{};
+    final fieldMap = <String, dynamic>{};
     fieldMap[versionField] = '';
     fieldMap[traceIdField] = span?.context?.traceId;
     fieldMap[spanIdField] = span?.context?.spanId;

--- a/example/default/json_serializable_span.dart
+++ b/example/default/json_serializable_span.dart
@@ -14,29 +14,48 @@
 
 import 'package:opentracing/opentracing.dart';
 
+/// Abstract class that identifies other classes being serializable as json.
+///
+/// Implementing this class will enable a class to be serialized using the
+/// JSON.encode method.
 class JsonSerializableSpan {
+  // ignore: public_member_api_docs
   static const String versionField = 'version';
+  // ignore: public_member_api_docs
   static const String traceIdField = 'traceId';
+  // ignore: public_member_api_docs
   static const String spanIdField = 'spanId';
+  // ignore: public_member_api_docs
   static const String sampledField = 'sampled';
+  // ignore: public_member_api_docs
   static const String baggageField = 'baggage';
+  // ignore: public_member_api_docs
   static const String parentSpanIdField = 'parentSpanId';
+  // ignore: public_member_api_docs
   static const String operationField = 'operation';
+  // ignore: public_member_api_docs
   static const String startField = 'start';
+  // ignore: public_member_api_docs
   static const String durationField = 'duration';
+  // ignore: public_member_api_docs
   static const String tagsField = 'tags';
+  // ignore: public_member_api_docs
   static const String logsField = 'logs';
 
+  // ignore: public_member_api_docs
   Span span;
 
+  // ignore: public_member_api_docs
   JsonSerializableSpan(this.span);
 
-  Map toJson() {
+  // ignore: public_member_api_docs
+  Map<String, dynamic> toJson() {
     return getFields();
   }
 
-  Map getFields() {
-    Map<String, dynamic> fieldMap = {};
+  // ignore: public_member_api_docs
+  Map<String, dynamic> getFields() {
+    Map<String, dynamic> fieldMap = <String, dynamic>{};
     fieldMap[versionField] = '';
     fieldMap[traceIdField] = span?.context?.traceId;
     fieldMap[spanIdField] = span?.context?.spanId;

--- a/lib/noop_tracer.dart
+++ b/lib/noop_tracer.dart
@@ -31,7 +31,3 @@ export 'src/noop_scope_manager.dart';
 export 'src/noop_span.dart';
 export 'src/noop_span_context.dart';
 export 'src/noop_tracer.dart';
-export 'src/reference.dart';
-export 'src/reference.dart';
-export 'src/span_context.dart';
-export 'src/span_context.dart';

--- a/lib/noop_tracer.dart
+++ b/lib/noop_tracer.dart
@@ -26,6 +26,12 @@
 
 library opentracing_noop;
 
+export 'src/noop_scope.dart';
+export 'src/noop_scope_manager.dart';
 export 'src/noop_span.dart';
 export 'src/noop_span_context.dart';
 export 'src/noop_tracer.dart';
+export 'src/reference.dart';
+export 'src/reference.dart';
+export 'src/span_context.dart';
+export 'src/span_context.dart';

--- a/lib/opentracing.dart
+++ b/lib/opentracing.dart
@@ -26,6 +26,8 @@
 
 library opentracing_dart;
 
+export 'src/abstract_scope.dart';
+export 'src/abstract_scope_manager.dart';
 export 'src/abstract_span.dart';
 export 'src/abstract_tracer.dart';
 export 'src/binary_carrier.dart';

--- a/lib/src/abstract_scope.dart
+++ b/lib/src/abstract_scope.dart
@@ -1,21 +1,35 @@
+// Copyright 2016 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'package:opentracing/opentracing.dart';
 
-/// A [Scope] formalizes the activation and deactivation of a [Span], usually
+/// A Scope formalizes the activation and deactivation of a [Span], usually
 /// from a CPU standpoint.
 ///
-/// Many times a [Span] will be extant ([Span].finish() has not been called)
+/// Many times a [Span] will be extant ([Span.finish] has not been called)
 /// despite being in a non-runnable state from a CPU/scheduler standpoint. For
 /// instance, a [Span] representing the client side of an RPC will be unfinished
-/// but blocked on IO while the RPC is still outstanding. A [Scope] defines when
+/// but blocked on IO while the RPC is still outstanding. A Scope defines when
 /// a given [Span] is scheduled and on the path.
 abstract class Scope {
-  /// Mark the end of the active period for the current thread and [Scope],
-  /// updating the [ScopeManager].active() in the process.
+  /// Mark the end of the active period for the current thread and Scope,
+  /// updating the [ScopeManager.active] in the process.
   ///
-  /// NOTE: Calling 'close' more than once on a single {@link Scope} instance
+  /// NOTE: Calling 'close' more than once on a single Scope instance
   /// leads to undefined behavior.
   void close();
 
-  /// Returns the [Span] that's been scoped by this [Scope]
+  /// The Span that's been scoped by this Scope.
   Span get span;
 }

--- a/lib/src/abstract_scope.dart
+++ b/lib/src/abstract_scope.dart
@@ -1,0 +1,21 @@
+import 'package:opentracing/opentracing.dart';
+
+/// A [Scope] formalizes the activation and deactivation of a [Span], usually
+/// from a CPU standpoint.
+///
+/// Many times a [Span] will be extant ([Span].finish() has not been called)
+/// despite being in a non-runnable state from a CPU/scheduler standpoint. For
+/// instance, a [Span] representing the client side of an RPC will be unfinished
+/// but blocked on IO while the RPC is still outstanding. A [Scope] defines when
+/// a given [Span] is scheduled and on the path.
+abstract class Scope {
+  /// Mark the end of the active period for the current thread and [Scope],
+  /// updating the [ScopeManager].active() in the process.
+  ///
+  /// NOTE: Calling 'close' more than once on a single {@link Scope} instance
+  /// leads to undefined behavior.
+  void close();
+
+  /// Returns the [Span] that's been scoped by this [Scope]
+  Span get span;
+}

--- a/lib/src/abstract_scope_manager.dart
+++ b/lib/src/abstract_scope_manager.dart
@@ -1,0 +1,25 @@
+import 'package:opentracing/opentracing.dart';
+
+/// The [ScopeManager] abstracts both the activation of [Span] instances via
+/// [ScopeManager].activate(Span, boolean)} and access to an active
+/// [Span]/[Scope] via [ScopeManager].active.
+abstract class ScopeManager {
+  /// Make a Span instance active.
+  ///
+  /// [span] that should become the [active] [Span]
+  /// When [finishSpanOnClose] is true, the [span] will automatically be
+  /// finished when [Scope].close() is called.
+  /// Returns a [Scope] instance to control the end of the active period for the
+  /// [Span]. It is a programming error to neglect calling [Scope].close() on
+  /// the returned instance.
+  Scope activate(Span span, {bool finishSpanOnClose});
+
+  /// Return the currently active [Scope] which can be used to access the
+  /// currently active [Scope].span.
+  /// If there is a [Scope] non-null scope, its wrapped [Span] becomes an
+  /// implicit parent(as [referenceChildOf]) of any newly-created
+  /// [Span] at [AbstractTracer].startSpan.
+  ///
+  /// Returns the [Scope], or null if none could be found.
+  Scope get active;
+}

--- a/lib/src/abstract_scope_manager.dart
+++ b/lib/src/abstract_scope_manager.dart
@@ -1,18 +1,32 @@
+// Copyright 2016 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'package:opentracing/opentracing.dart';
 
-/// The [ScopeManager] abstracts both the activation of [Span] instances via
-/// [ScopeManager].activate(Span, boolean)} and access to an active
-/// [Span]/[Scope] via [ScopeManager].active.
+/// The ScopeManager abstracts both the activation of [Span] instances via
+/// ScopeManager.activate(Span, boolean)} and access to an active
+/// [Span]/[Scope] via ScopeManager.active.
 abstract class ScopeManager {
   /// Make a Span instance active.
   ///
-  /// [span] that should become the [active] [Span]
+  /// Span that should become the active Span
   /// When [finishSpanOnClose] is true, the [span] will automatically be
-  /// finished when [Scope].close() is called.
-  /// Returns a [Scope] instance to control the end of the active period for the
-  /// [Span]. It is a programming error to neglect calling [Scope].close() on
+  /// finished when Scope.close() is called.
+  /// Returns a Scope instance to control the end of the active period for the
+  /// [Span]. It is a programming error to neglect calling Scope.close() on
   /// the returned instance.
-  Scope activate(Span span, {bool finishSpanOnClose});
+  Scope activate(Span span, bool finishSpanOnClose);
 
   /// Return the currently active [Scope] which can be used to access the
   /// currently active [Scope].span.
@@ -22,4 +36,6 @@ abstract class ScopeManager {
   ///
   /// Returns the [Scope], or null if none could be found.
   Scope get active;
+
+  set active(Scope value);
 }

--- a/lib/src/abstract_scope_manager.dart
+++ b/lib/src/abstract_scope_manager.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:meta/meta.dart';
 import 'package:opentracing/opentracing.dart';
 
 /// The ScopeManager abstracts both the activation of [Span] instances via
@@ -37,5 +38,7 @@ abstract class ScopeManager {
   /// Returns the [Scope], or null if none could be found.
   Scope get active;
 
+  /// DO NOT USE THIS! This is only to be used by Scope OR ScopeManager.
+  @protected
   set active(Scope value);
 }

--- a/lib/src/abstract_span.dart
+++ b/lib/src/abstract_span.dart
@@ -37,6 +37,9 @@ abstract class Span {
   /// Each span has a UTC timestamp describing when it started.
   DateTime get startTime;
 
+  /// Each span has a UTC timestamp describing when it started.
+  set startTime(DateTime value);
+
   /// A Span may reference zero or more Spans that are causally related.
   /// OpenTracing presently defines two types of references: ChildOf and
   /// FollowsFrom. Both reference types specifically model direct causal

--- a/lib/src/abstract_tracer.dart
+++ b/lib/src/abstract_tracer.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 
 import 'package:opentracing/opentracing.dart';
+import 'package:opentracing/src/abstract_scope_manager.dart';
 
 /// AbstractTracer provides the abstract definition for a Tracer and contains
 /// some default method implementations.
@@ -53,6 +54,15 @@ abstract class AbstractTracer {
   ///     var wireCtx = Tracer.extract(Constants.formatHttpHeaders, headersCarrier);
   ///     var serverSpan = Tracer.startSpan('...', { childOf : wireCtx });
   SpanContext extract(String format, dynamic carrier);
+
+  /// Returns the current [ScopeManager], which may be a noop but may not be
+  /// null.
+  ScopeManager get scopeManager;
+
+  /// Returns the activer [Span]. This is a shorthand for
+  /// `Tracer.scopeManager().active().span()` and null will be returned if
+  /// [ScopeManager].active()} is null.
+  Span activeSpan();
 
   /// Request that any buffered or in-memory data is flushed out of the process.
   /// Optionally a callback function with the signature `function(err)` will be

--- a/lib/src/abstract_tracer.dart
+++ b/lib/src/abstract_tracer.dart
@@ -59,10 +59,12 @@ abstract class AbstractTracer {
   /// null.
   ScopeManager get scopeManager;
 
+  set scopeManager(ScopeManager value);
+
   /// Returns the activer [Span]. This is a shorthand for
   /// `Tracer.scopeManager().active().span()` and null will be returned if
   /// [ScopeManager].active()} is null.
-  Span activeSpan();
+  Span get activeSpan => scopeManager?.active?.span;
 
   /// Request that any buffered or in-memory data is flushed out of the process.
   /// Optionally a callback function with the signature `function(err)` will be

--- a/lib/src/noop_scope.dart
+++ b/lib/src/noop_scope.dart
@@ -17,13 +17,12 @@ import 'package:opentracing/opentracing.dart';
 
 /// The No-op implementation of [Scope] in which all operations are no-op
 class NoopScope implements Scope {
+  static final Span _noopSpan = new NoopSpan();
+
   /// Returns a new NoopScope, which will use the supplied Span. If no Span is
   /// supplied, a static instance of a NoopSpan will be used.
-  NoopScope({Span span}) {
-    _span = span ?? _span;
-  }
-
-  static Span _span = new NoopSpan();
+  NoopScope({Span span}) : _span = span ?? _noopSpan;
+  final Span _span;
 
   @override
   void close() {}

--- a/lib/src/noop_scope.dart
+++ b/lib/src/noop_scope.dart
@@ -1,0 +1,18 @@
+import 'package:opentracing/noop_tracer.dart';
+import 'package:opentracing/opentracing.dart';
+
+/// The No-op implementation of [Scope] in which all operations are no-op
+class NoOpScope implements Scope {
+  /// Returns a NoopScope.
+  NoOpScope() {
+    _span ??= new NoopSpan();
+  }
+
+  static Span _span;
+
+  @override
+  void close() {}
+
+  @override
+  Span get span => _span;
+}

--- a/lib/src/noop_scope.dart
+++ b/lib/src/noop_scope.dart
@@ -1,14 +1,29 @@
+// Copyright 2016 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'package:opentracing/noop_tracer.dart';
 import 'package:opentracing/opentracing.dart';
 
 /// The No-op implementation of [Scope] in which all operations are no-op
-class NoOpScope implements Scope {
-  /// Returns a NoopScope.
-  NoOpScope() {
-    _span ??= new NoopSpan();
+class NoopScope implements Scope {
+  /// Returns a new NoopScope, which will use the supplied Span. If no Span is
+  /// supplied, a static instance of a NoopSpan will be used.
+  NoopScope({Span span}) {
+    _span = span ?? _span;
   }
 
-  static Span _span;
+  static Span _span = new NoopSpan();
 
   @override
   void close() {}

--- a/lib/src/noop_scope_manager.dart
+++ b/lib/src/noop_scope_manager.dart
@@ -1,0 +1,20 @@
+import 'package:opentracing/noop_tracer.dart';
+import 'package:opentracing/opentracing.dart';
+
+/// The No-op implementation of a [ScopeManager] in which all operations are
+/// no-ops.
+class NoOpScopeManager implements ScopeManager {
+  /// Returns a NoOpScopeManager.
+  NoOpScopeManager() {
+    _scope ??= new NoOpScope();
+  }
+  static Scope _scope;
+
+  @override
+  Scope activate(Span span, {bool finishSpanOnClose}) {
+    return active;
+  }
+
+  @override
+  Scope get active => _scope;
+}

--- a/lib/src/noop_scope_manager.dart
+++ b/lib/src/noop_scope_manager.dart
@@ -1,20 +1,40 @@
+// Copyright 2016 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'package:opentracing/noop_tracer.dart';
 import 'package:opentracing/opentracing.dart';
 
 /// The No-op implementation of a [ScopeManager] in which all operations are
 /// no-ops.
-class NoOpScopeManager implements ScopeManager {
-  /// Returns a NoOpScopeManager.
-  NoOpScopeManager() {
-    _scope ??= new NoOpScope();
+class NoopScopeManager extends ScopeManager {
+  /// Returns a new NoopScopeManager.
+  NoopScopeManager() {
+    _scope ??= new NoopScope();
   }
   static Scope _scope;
 
   @override
-  Scope activate(Span span, {bool finishSpanOnClose}) {
+  Scope activate(Span span, bool finishSpanOnClose) {
+    _scope = new NoopScope(span: span);
     return active;
   }
 
   @override
   Scope get active => _scope;
+
+  @override
+  set active(Scope value) {
+    _scope = value;
+  }
 }

--- a/lib/src/noop_span.dart
+++ b/lib/src/noop_span.dart
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:opentracing/src/span_context.dart';
-import 'abstract_span.dart';
-import 'reference.dart';
-import 'noop_span_context.dart';
 import 'dart:async';
-import 'logdata.dart';
+
+import 'package:opentracing/noop_tracer.dart';
+import 'package:opentracing/opentracing.dart';
 
 /// The No-op implementation of a [Span] in which all operations are no-ops.
 class NoopSpan implements Span {
+  static NoopSpanContext _noopSpanContext = new NoopSpanContext();
+
   @override
-  SpanContext context = new NoopSpanContext();
+  SpanContext context = _noopSpanContext;
 
   @override
   SpanContext parentContext;
@@ -64,4 +64,7 @@ class NoopSpan implements Span {
   Future<Span> get whenFinished async {
     return new Future<Span>.value(null);
   }
+
+  @override
+  set startTime(DateTime value) {}
 }

--- a/lib/src/noop_span_context.dart
+++ b/lib/src/noop_span_context.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'span_context.dart';
+import 'package:opentracing/opentracing.dart';
 
 /// The no-op implementation of [SpanContext] in which all operations are No-op
 class NoopSpanContext extends SpanContext {

--- a/lib/src/noop_tracer.dart
+++ b/lib/src/noop_tracer.dart
@@ -19,7 +19,7 @@ import 'package:opentracing/opentracing.dart';
 
 /// The No-op implementation of [AbstractTracer] in which all operations are no-op
 class NoopTracer extends AbstractTracer {
-  static ScopeManager _scopeManager = new NoOpScopeManager();
+  static ScopeManager _scopeManager = new NoopScopeManager();
 
   @override
   NoopSpan startSpan(String operationName,
@@ -35,17 +35,17 @@ class NoopTracer extends AbstractTracer {
 
   @override
   SpanContext extract(String format, dynamic carrier) {
-    return scopeManager.active.span.context;
+    return scopeManager?.active?.span?.context;
   }
 
   @override
   Future<dynamic> flush() async {}
 
   @override
-  Span activeSpan() {
-    return scopeManager.active.span;
-  }
+  ScopeManager get scopeManager => _scopeManager;
 
   @override
-  ScopeManager get scopeManager => _scopeManager;
+  set scopeManager(ScopeManager value) {
+    _scopeManager = value;
+  }
 }

--- a/lib/src/noop_tracer.dart
+++ b/lib/src/noop_tracer.dart
@@ -14,20 +14,20 @@
 
 import 'dart:async';
 
-import 'noop_span.dart';
-import 'reference.dart';
-import 'span_context.dart';
-import 'abstract_tracer.dart';
+import 'package:opentracing/noop_tracer.dart';
+import 'package:opentracing/opentracing.dart';
 
 /// The No-op implementation of [AbstractTracer] in which all operations are no-op
 class NoopTracer extends AbstractTracer {
+  static ScopeManager _scopeManager = new NoOpScopeManager();
+
   @override
   NoopSpan startSpan(String operationName,
       {SpanContext childOf,
       List<Reference> references,
       Map<String, dynamic> tags,
       DateTime startTime}) {
-    return new NoopSpan();
+    return scopeManager.active.span;
   }
 
   @override
@@ -35,9 +35,17 @@ class NoopTracer extends AbstractTracer {
 
   @override
   SpanContext extract(String format, dynamic carrier) {
-    return null;
+    return scopeManager.active.span.context;
   }
 
   @override
   Future<dynamic> flush() async {}
+
+  @override
+  Span activeSpan() {
+    return scopeManager.active.span;
+  }
+
+  @override
+  ScopeManager get scopeManager => _scopeManager;
 }

--- a/test/unit/binary_carrier_test.dart
+++ b/test/unit/binary_carrier_test.dart
@@ -22,7 +22,7 @@ void main() {
       ByteBuffer buffer = new Uint8List(8).buffer;
       BinaryCarrier carrier = new BinaryCarrier(buffer);
 
-      expect(identical(carrier.buffer, buffer), isTrue);
+      expect(carrier.buffer, same(buffer));
     });
 
     test('buffer can be set after construction.', () {
@@ -31,7 +31,7 @@ void main() {
       ByteBuffer newBuffer = new Uint8List(4).buffer;
       carrier.buffer = newBuffer;
 
-      expect(identical(carrier.buffer, newBuffer), isTrue);
+      expect(carrier.buffer, same(newBuffer));
     });
   });
 }

--- a/test/unit/global_tracer_test.dart
+++ b/test/unit/global_tracer_test.dart
@@ -23,7 +23,7 @@ void main() {
   test('Global tracer is a singleton', () {
     AbstractTracer tracerOne = globalTracer();
     AbstractTracer tracerTwo = globalTracer();
-    expect(identical(tracerOne, tracerTwo), isTrue);
+    expect(tracerOne, same(tracerTwo));
   });
 
   test('Verify InitGlobalTracer changes the global tracer', () {
@@ -59,12 +59,17 @@ class TestTracer extends AbstractTracer {
 
   @override
   Future<dynamic> flush({Function callback: null}) async {}
+
   @override
-  Span activeSpan() {
+  Span get activeSpan {
     return new NoopSpan();
   }
 
-  // TODO: implement scopeManager
   @override
   ScopeManager get scopeManager => null;
+
+  @override
+  set scopeManager(ScopeManager value) {
+    // no op
+  }
 }

--- a/test/unit/global_tracer_test.dart
+++ b/test/unit/global_tracer_test.dart
@@ -59,4 +59,12 @@ class TestTracer extends AbstractTracer {
 
   @override
   Future<dynamic> flush({Function callback: null}) async {}
+  @override
+  Span activeSpan() {
+    return new NoopSpan();
+  }
+
+  // TODO: implement scopeManager
+  @override
+  ScopeManager get scopeManager => null;
 }

--- a/test/unit/noop_scope_manager_test.dart
+++ b/test/unit/noop_scope_manager_test.dart
@@ -20,17 +20,19 @@ void main() {
   group('NoOpScopeManager: verify', () {
     test('that NoOpScope is inert', () {
       NoopSpan spanA = new NoopSpan();
-      NoOpScopeManager scopeManager = new NoOpScopeManager();
-      expect(scopeManager.active, new isInstanceOf<NoOpScope>());
-      scopeManager.activate(spanA);
-      expect(identical(spanA, scopeManager.active), isFalse);
-      expect(scopeManager.activate(spanA), new isInstanceOf<NoOpScope>());
+      NoopScopeManager scopeManager = new NoopScopeManager();
+      bool finishOnSpanClose = false;
+      expect(scopeManager.active, new isInstanceOf<NoopScope>());
+      scopeManager.activate(spanA, finishOnSpanClose);
+      expect(scopeManager.active.span, same(spanA));
+      expect(scopeManager.activate(spanA, finishOnSpanClose),
+          new isInstanceOf<NoopScope>());
     });
 
     test('that NoOpScope.span is same instance', () {
-      NoOpScopeManager scopeManagerOne = new NoOpScopeManager();
-      NoOpScopeManager scopeManagerTwo = new NoOpScopeManager();
-      expect(identical(scopeManagerOne.active, scopeManagerTwo.active), isTrue);
+      NoopScopeManager scopeManagerOne = new NoopScopeManager();
+      NoopScopeManager scopeManagerTwo = new NoopScopeManager();
+      expect(scopeManagerTwo.active, same(scopeManagerOne.active));
     });
   });
 }

--- a/test/unit/noop_scope_manager_test.dart
+++ b/test/unit/noop_scope_manager_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2016 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:test/test.dart';
+
+import 'package:opentracing/noop_tracer.dart';
+
+void main() {
+  group('NoOpScopeManager: verify', () {
+    test('that NoOpScope is inert', () {
+      NoopSpan spanA = new NoopSpan();
+      NoOpScopeManager scopeManager = new NoOpScopeManager();
+      expect(scopeManager.active, new isInstanceOf<NoOpScope>());
+      scopeManager.activate(spanA);
+      expect(identical(spanA, scopeManager.active), isFalse);
+      expect(scopeManager.activate(spanA), new isInstanceOf<NoOpScope>());
+    });
+
+    test('that NoOpScope.span is same instance', () {
+      NoOpScopeManager scopeManagerOne = new NoOpScopeManager();
+      NoOpScopeManager scopeManagerTwo = new NoOpScopeManager();
+      expect(identical(scopeManagerOne.active, scopeManagerTwo.active), isTrue);
+    });
+  });
+}

--- a/test/unit/noop_scope_test.dart
+++ b/test/unit/noop_scope_test.dart
@@ -22,7 +22,6 @@ void main() {
       NoOpScope scope = new NoOpScope();
       expect(scope.span, new isInstanceOf<NoopSpan>());
       expect(scope.close, isNot(throwsException));
-      expect(scope.close(), isNot(new isInstanceOf<Error>()));
     });
 
     test('that NoOpScope.span is same instance', () {

--- a/test/unit/noop_scope_test.dart
+++ b/test/unit/noop_scope_test.dart
@@ -17,17 +17,17 @@ import 'package:test/test.dart';
 import 'package:opentracing/noop_tracer.dart';
 
 void main() {
-  group('NoOpScope: verify', () {
+  group('NoopScope: verify', () {
     test('that NoOpScope is inert', () {
-      NoOpScope scope = new NoOpScope();
+      NoopScope scope = new NoopScope();
       expect(scope.span, new isInstanceOf<NoopSpan>());
       expect(scope.close, isNot(throwsException));
     });
 
-    test('that NoOpScope.span is same instance', () {
-      NoOpScope scopeOne = new NoOpScope();
-      NoOpScope scopeTwo = new NoOpScope();
-      expect(identical(scopeOne.span, scopeTwo.span), isTrue);
+    test('that NoopScope.span is same instance', () {
+      NoopScope scopeOne = new NoopScope();
+      NoopScope scopeTwo = new NoopScope();
+      expect(scopeOne.span, same(scopeTwo.span));
     });
   });
 }

--- a/test/unit/noop_scope_test.dart
+++ b/test/unit/noop_scope_test.dart
@@ -1,0 +1,34 @@
+// Copyright 2016 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:test/test.dart';
+
+import 'package:opentracing/noop_tracer.dart';
+
+void main() {
+  group('NoOpScope: verify', () {
+    test('that NoOpScope is inert', () {
+      NoOpScope scope = new NoOpScope();
+      expect(scope.span, new isInstanceOf<NoopSpan>());
+      expect(scope.close, isNot(throwsException));
+      expect(scope.close(), isNot(new isInstanceOf<Error>()));
+    });
+
+    test('that NoOpScope.span is same instance', () {
+      NoOpScope scopeOne = new NoOpScope();
+      NoOpScope scopeTwo = new NoOpScope();
+      expect(identical(scopeOne.span, scopeTwo.span), isTrue);
+    });
+  });
+}

--- a/test/unit/noop_tracer_test.dart
+++ b/test/unit/noop_tracer_test.dart
@@ -40,9 +40,8 @@ void main() {
     expect(noopSpan.context.baggage, expectedContext.baggage);
   });
 
-  test('Verify startSpan returns NoOpSpan from NoOpScopeManager', () {
+  test('Verify startSpan returns NoopSpan from NoopScopeManager', () {
     NoopTracer noOpTracer = new NoopTracer();
-    expect(
-        identical(noOpTracer.startSpan(''), noOpTracer.activeSpan()), isTrue);
+    expect(noOpTracer.startSpan(''), same(noOpTracer.activeSpan));
   });
 }

--- a/test/unit/noop_tracer_test.dart
+++ b/test/unit/noop_tracer_test.dart
@@ -16,7 +16,7 @@ import 'package:test/test.dart';
 import 'package:opentracing/noop_tracer.dart';
 
 void main() {
-  test('Verify startSpan returns NoopSpan', () {
+  test('Verify startSpan returns a NoopSpan', () {
     NoopTracer noopTracer = new NoopTracer();
     NoopSpan noopSpan = noopTracer.startSpan("opName");
     expect(noopSpan, new isInstanceOf<NoopSpan>());
@@ -38,5 +38,11 @@ void main() {
     expect(noopSpan.context.spanId, expectedContext.spanId);
     expect(noopSpan.context.sampled, expectedContext.sampled);
     expect(noopSpan.context.baggage, expectedContext.baggage);
+  });
+
+  test('Verify startSpan returns NoOpSpan from NoOpScopeManager', () {
+    NoopTracer noOpTracer = new NoopTracer();
+    expect(
+        identical(noOpTracer.startSpan(''), noOpTracer.activeSpan()), isTrue);
   });
 }


### PR DESCRIPTION
### Description

For platforms not propagating the call-context, it's inconvenient to pass the active Span from function to function manually, so OpenTracing should provide, for those platforms, that Tracer contains a Scope Manager that grants access to the active Span through a container, called Scope (using some call-context storage, such as thread-local or coroutine-local)

Driving use case: We want to trace what happens from the time a pre-authenticated user navigates to Wdesk, until they have arrived at home and can see the file/folder list populated.

To permit this, we need to support the concept of ScopeManager and ActiveSpan in opentracing_dart.

### Changes

1. [Added AbstractScope](https://github.com/Workiva/opentracing_dart/pull/34/files#diff-99e23a9e15d382d3e46f4e9c4c6efd5fR11)
2. [Added AbstractScopeManager](https://github.com/Workiva/opentracing_dart/pull/34/files#diff-7ee99de4fd1548b68ea92d71f811b628R6)
3. [Added startTime setter to AbstractSpan](https://github.com/Workiva/opentracing_dart/pull/34/files#diff-e86db1102e09e7e2572fbdec895889e4R41)
4. [Added ScopeManager getter to AbstractTracer](https://github.com/Workiva/opentracing_dart/pull/34/files#diff-a9040a553676bd386382f801be7551b5R60)
5. [Added activeSpan getter to AbstractTracer](https://github.com/Workiva/opentracing_dart/pull/34/files#diff-a9040a553676bd386382f801be7551b5R65)
6. [Added NoOpScope](https://github.com/Workiva/opentracing_dart/pull/34/files#diff-b6f6815c17c938af5565df94c24910a3R5)
7. [Added NoOpScopeManager](https://github.com/Workiva/opentracing_dart/pull/34/files#diff-473f89d6d49af1525b0b8b0af1b3b228R6)
8. [Switched to using a single instance for NoOpSpanContext in NoOpSpan](https://github.com/Workiva/opentracing_dart/pull/34/files#diff-2faac055316536e7e88e6ff8c8fa9bf6R22)
9. [Switched to using a single instance for a NoOpTracer's ScopeManager](https://github.com/Workiva/opentracing_dart/pull/34/files#diff-e1af976c0aec85596d40def1ce8173f7R22)
10. Added various tests.
11. Some opportunistic refactors around lints.

### Testing/QA

- [ ] CI passes


### Code Review

@Workiva/app-frameworks



