### PR TITLE
CPLAT-4198 : added Meta dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,9 @@ homepage: http://opentracing.io/
 environment:
   sdk: '>=1.24.3<3.0.0'
 
+dependencies:
+  meta: ^1.1.0
+
 dev_dependencies:
   build_runner: ">=0.6.0 <1.0.0"
   build_test: ">=0.9.0 <1.0.0"


### PR DESCRIPTION
## Problem:

When attempting a publish dry run, it was noticed that opentracing_dart uses the Meta package but doesn't list it as a dependency.

## Solution:

Added Meta dependency

## Result:

```shell

wf14358:opentracing_dart dustinlessard$ pub publish --dry-run
Publishing opentracing 1.0.0 to https://pub.dartlang.org:
|-- .gitignore
|-- .travis.yml
|-- CHANGELOG.md
|-- Dockerfile
|-- LICENSE
|-- NOTICE
|-- README.md
|-- analysis_options.yaml
|-- aviary.yaml
|-- example
|   '-- default
|       |-- example.dart
|       |-- index.html
|       |-- json_serializable_span.dart
|       '-- response.json
|-- lib
|   |-- noop_tracer.dart
|   |-- opentracing.dart
|   '-- src
|       |-- abstract_scope.dart
|       |-- abstract_scope_manager.dart
|       |-- abstract_span.dart
|       | (11 more...)
|       |-- noop_tracer.dart
|       |-- reference.dart
|       '-- span_context.dart
|-- pubspec.yaml
|-- test
|   '-- unit
|       |-- abstract_tracer_test.dart
|       |-- binary_carrier_test.dart
|       |-- errors_test.dart
|       | (5 more...)
|       |-- noop_tracer_test.dart
|       |-- reference_test.dart
|       '-- span_context_test.dart
'-- tool
    '-- test.sh

Package has 0 warnings.

```