### PR TITLE
CPLAT-7488 Run Dart 2 unit tests on dart2js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,8 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:389211 as build
-ARG BUILD_ID
-ARG BUILD_NUMBER
-ARG BUILD_URL
-ARG GIT_COMMIT
-ARG GIT_BRANCH
-ARG GIT_TAG
-ARG GIT_COMMIT_RANGE
-ARG GIT_HEAD_URL
-ARG GIT_MERGE_HEAD
-ARG GIT_MERGE_BRANCH
+  
+FROM google/dart:2.5 as dart2
 
-WORKDIR /build/
-ADD . /build/
-RUN pub get && \
-    dartfmt --set-exit-if-changed -n lib test example && \
-    dartanalyzer lib test example && \
-    pub run test -p vm -p chrome
-
-ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock
+WORKDIR /build
+ADD pubspec.* /build/
+RUN pub get
 
 FROM scratch
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,14 +5,14 @@ author: The OpenTracing Authors <https://groups.google.com/forum/#!forum/distrib
 homepage: http://opentracing.io/
 
 environment:
-  sdk: '>=1.24.3<3.0.0'
+  sdk: '>=1.24.3 <3.0.0'
 
 dependencies:
   meta: ^1.1.0
 
 dev_dependencies:
-  build_runner: ">=0.6.0 <1.0.0"
-  build_test: ">=0.9.0 <1.0.0"
-  build_web_compilers: ">=0.2.0 <1.0.0"
+  build_runner: ">=0.6.0 <2.0.0"
+  build_test: ">=0.9.0 <2.0.0"
+  build_web_compilers: ">=0.2.0 <3.0.0"
   coverage: ">=0.10.0 <0.13.0"
   test: ">=0.12.30 <2.0.0"

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -2,15 +2,14 @@
 
 # Fast fail the script on failures.
 set -e
+set -x
 
 DART_VERSION=$(dart --version 2>&1)
 DART_2_PREFIX="Dart VM version: 2"
 
 
 if [[ $DART_VERSION = $DART_2_PREFIX* ]]; then
-    echo -e 'pub run build_runner test -- -p vm -p chrome'
-    pub run build_runner test -- -p vm -p chrome
+    pub run build_runner test --release -- -p chrome
 else
-    echo -e 'pub run test -p vm -p chrome'
     pub run test -p vm -p chrome
 fi


### PR DESCRIPTION
### Problem
The unit tests won't compile anymore with the current dependencies. It might also be nice to run our Dart 2 unit tests on dart2js.

### Solution
- Updated dependencies so the tests will build again
- Simplified the Dockerfile, since everything we were doing in there is also done in Travis
- Updated the test script to run the unit tests using dart2js for Dart 2