### PR TITLE
TESTING: Release opentracing_dart 1.0.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: opentracing
-version: 1.0.3
+version: 1.0.4
 description: This library is the Open Tracing API written in Dart. It is intended for use both on the server and in the browser.
 homepage: http://opentracing.io/
 


### PR DESCRIPTION
This is a test pull request triggered from w-rmconsole and is not intended for merge.

Pull Requests included in release:
* Patch changes:
	* [Remove deprecated authors field from pubspec.yaml](https://github.com/Workiva/opentracing_dart/pull/43)
	* [Release opentracing_dart 1.0.3](https://github.com/Workiva/opentracing_dart/pull/46)


Diff Between Last Tag and Proposed Release: https://github.com/Workiva/opentracing_dart/compare/1.0.3...Workiva:release_opentracing_dart_1.0.4
Diff Between Last Tag and New Tag: https://github.com/Workiva/opentracing_dart/compare/1.0.3...1.0.4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4796034024996864/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4796034024996864/?pull_number=48&repo_name=Workiva%2Fopentracing_dart)