### PR TITLE
Raise analyzer minimum & unpin meta

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
-  meta: ^1.2.2
+  meta: ^1.6.0
 
 dev_dependencies:
   build_runner: '>=1.7.1 <3.0.0'


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This will require analyzer 1.7.2+ and now that we're past analyzer 1.7.1
we can unpin the meta dependency. (We had restricted it to <1.7.0 in many places)

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/analyzer1_unpin_meta`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/analyzer1_unpin_meta)