### PR TITLE
cleanup_workiva_build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM drydock-prod.workiva.net/workiva/dart2_base_image:2
-WORKDIR /build/
-ADD pubspec.yaml /build/
-RUN dart pub get
-FROM scratch


### PR DESCRIPTION
# Summary
Now that we've moved over to github actions we can remove the Dockerfile
that was used for Workiva Build.

# QA
- [ ] If CI continues to pass, the Dockerfile was not used and can be merged

[_Created by Sourcegraph batch change `Workiva/cleanup_workiva_build`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/cleanup_workiva_build)