### PR TITLE
no_entrypoint_imports

### DIFF
--- a/lib/src/abstract_scope.dart
+++ b/lib/src/abstract_scope.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:opentracing/opentracing.dart';
+
 
 /// A Scope formalizes the activation and deactivation of a [Span], usually
 /// from a CPU standpoint.

--- a/lib/src/abstract_scope_manager.dart
+++ b/lib/src/abstract_scope_manager.dart
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import 'package:meta/meta.dart';
-import 'package:opentracing/opentracing.dart';
+
 
 /// The ScopeManager abstracts both the activation of [Span] instances via
 /// ScopeManager.activate(Span, boolean)} and access to an active

--- a/lib/src/abstract_span.dart
+++ b/lib/src/abstract_span.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:opentracing/opentracing.dart';
+
 import 'dart:async';
 
 /// [Span] represents a logical unit of work as part of a broader [Trace]. Examples

--- a/lib/src/abstract_tracer.dart
+++ b/lib/src/abstract_tracer.dart
@@ -14,7 +14,7 @@
 
 import 'dart:async';
 
-import 'package:opentracing/opentracing.dart';
+
 import 'package:opentracing/src/abstract_scope_manager.dart';
 
 /// AbstractTracer provides the abstract definition for a Tracer and contains

--- a/lib/src/noop_scope.dart
+++ b/lib/src/noop_scope.dart
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:opentracing/noop_tracer.dart';
-import 'package:opentracing/opentracing.dart';
+
+
 
 /// The No-op implementation of [Scope] in which all operations are no-op
 class NoopScope implements Scope {

--- a/lib/src/noop_scope_manager.dart
+++ b/lib/src/noop_scope_manager.dart
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:opentracing/noop_tracer.dart';
-import 'package:opentracing/opentracing.dart';
+
+
 
 /// The No-op implementation of a [ScopeManager] in which all operations are
 /// no-ops.

--- a/lib/src/noop_span.dart
+++ b/lib/src/noop_span.dart
@@ -14,8 +14,8 @@
 
 import 'dart:async';
 
-import 'package:opentracing/noop_tracer.dart';
-import 'package:opentracing/opentracing.dart';
+
+
 
 /// The No-op implementation of a [Span] in which all operations are no-ops.
 class NoopSpan implements Span {

--- a/lib/src/noop_span_context.dart
+++ b/lib/src/noop_span_context.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:opentracing/opentracing.dart';
+
 
 /// The no-op implementation of [SpanContext] in which all operations are No-op
 class NoopSpanContext extends SpanContext {

--- a/lib/src/noop_tracer.dart
+++ b/lib/src/noop_tracer.dart
@@ -14,8 +14,8 @@
 
 import 'dart:async';
 
-import 'package:opentracing/noop_tracer.dart';
-import 'package:opentracing/opentracing.dart';
+
+
 
 /// The No-op implementation of [AbstractTracer] in which all operations are no-op
 class NoopTracer extends AbstractTracer {


### PR DESCRIPTION
## Problem

An entrypoint import can be defined as an import within `lib/src` that imports a file within `lib/*.dart` (the entrypoints of a dart package). These imports are always unnecessary, and can contribute to slower dart build performance.

## Solution

This PR naively removes every entrypoint import within the repo, and updates the `gha-dart/.../checks.yaml` to the latest version. In order to merge this PR a few manual changes must be performed:

- Navigate to every file which has analysis errors caused from the missing import. Rely on intellisense to import the necessary symbol from the specific file, not the entrypoint import
- Implement the `no_entrypoint_imports` additional-checks option in `gha-dart@v2.10.13` that was added in [this PR](https://github.com/Workiva/gha-dart/pull/716). This will prevent new entrypoint imports from getting added once this PR merges

Our request to teams is to perform the above tasks, so we can default enable the `no_entrypoint_imports` check for all gha-dart consumers. Please reach out to [#support-frontend-dx](https://workiva.enterprise.slack.com/archives/C03ESR91BNU) for any questions or issues

## QA

- [ ] This pr is heavily dependant on the analysis server, and as such CI passes should be sufficient

[_Created by Sourcegraph batch change `Workiva/no_entrypoint_imports`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/no_entrypoint_imports)